### PR TITLE
bug: fix shared state among exercises

### DIFF
--- a/client/src/components/Workout/GuidedExercise.jsx
+++ b/client/src/components/Workout/GuidedExercise.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 
 import NumberDial from './NumberDial';
 import Dictaphone from './VoiceRecognition/Dictaphone';
+import DictaphoneDisabled from './VoiceRecognition/DictaphoneDisabled';
 import WorkoutStatesEnum from './WorkoutFlowStates';
 import { ExerciseShape } from './WorkoutPropTypes';
 import theme from '../../theme';
@@ -363,15 +364,22 @@ export default function GuidedExercise({
             </Typography>
           </Box>
         </Popover>
-        <Dictaphone
-          slideIsInView={slideIsInView}
-          timerToggle={handleTimerToggle}
-          incrementTimer={handleTimerAddition}
-          incrementTimerCustom={handleTimerCustomAddition}
-          decrementTimerCustom={handleTimerCustomSubtraction}
-          finishSet={handleFinishedSet}
-          pause={pause}
-        />
+        <Box>
+          {slideIsInView ? (
+            <Dictaphone
+              slideIsInView={slideIsInView}
+              timerToggle={handleTimerToggle}
+              incrementTimer={handleTimerAddition}
+              incrementTimerCustom={handleTimerCustomAddition}
+              decrementTimerCustom={handleTimerCustomSubtraction}
+              finishSet={handleFinishedSet}
+              pause={pause}
+            />
+          ) : (
+            <DictaphoneDisabled />
+          )}
+        </Box>
+
       </Box>
     </Paper>
   );

--- a/client/src/components/Workout/VoiceRecognition/Dictaphone.jsx
+++ b/client/src/components/Workout/VoiceRecognition/Dictaphone.jsx
@@ -27,7 +27,6 @@ function Dictaphone({
   decrementTimerCustom,
   finishSet,
   pause,
-  slideIsInView,
 }) {
   const commands = [
     {
@@ -87,117 +86,94 @@ function Dictaphone({
   };
 
   return (
-    <Box>
-      {slideIsInView ? (
-        <Box sx={{ display: 'flex' }}>
+    <Box sx={{ display: 'flex' }}>
 
-          <Tooltip
-            sx={{ color: theme.palette.secondary.main }}
-            title={(
-              <div>
-                Command Phrases: <br />
-                <br />
-                {Object.entries(voiceCommands).map(([command, data]) => (
-                  <div key={command}>
-                    <strong>{data.description}</strong>: {data.phrases.join(', ')}
-                  </div>
-                ))}
+      <Tooltip
+        sx={{ color: theme.palette.secondary.main }}
+        title={(
+          <div>
+            Command Phrases: <br />
+            <br />
+            {Object.entries(voiceCommands).map(([command, data]) => (
+              <div key={command}>
+                <strong>{data.description}</strong>: {data.phrases.join(', ')}
               </div>
-        )}
-          >
-            <IconButton disableFocusRipple disableTouchRipple>
-              <InfoIcon />
-            </IconButton>
-          </Tooltip>
+            ))}
+          </div>
+)}
+      >
+        <IconButton disableFocusRipple disableTouchRipple>
+          <InfoIcon />
+        </IconButton>
+      </Tooltip>
 
-          { browserSupportsSpeechRecognition ? (
-            <Tooltip
-              title={(
-                <div>
-                  Your browser supports voice recognition. <br />
-                  <br />
-                  Troubleshooting: <br />
-                  Voice control is not supported across all browsers. <br />
-                  The best native experience is on desktop Google Chrome. <br />
-                  Ensure that you give microphone permissions to AIRON.
-                </div>
-            )}
-              sx={{ color: theme.palette.secondary.main }}
-            >
-              <IconButton disableFocusRipple disableTouchRipple>
-                <RecordVoiceOverIcon />
-              </IconButton>
-            </Tooltip>
-          ) : (
-            <Tooltip
-              title={(
-                <div>
-                  Your browser does not support voice recognition. <br />
-                  <br />
-                  Troubleshooting: <br />
-                  Voice control is not supported across all browsers. <br />
-                  The best native experience is on desktop Google Chrome. <br />
-                  Ensure that you give microphone permissions to AIRON.
-                </div>
-          )}
-              sx={{ color: theme.palette.secondary.main }}
-            >
-              <IconButton disableFocusRipple disableTouchRipple>
-                <VoiceOverOffIcon />
-              </IconButton>
-            </Tooltip>
-          )}
-
-          <Tooltip
-            sx={{ color: theme.palette.secondary.main }}
-            title={(
-              <div>
-                Speech Transcript: <br />
-                <br />
-                {transcript}
-              </div>
-        )}
-          >
-            <IconButton disableFocusRipple disableTouchRipple>
-              <SpeakerNotesIcon />
-            </IconButton>
-          </Tooltip>
-
-          { listening ? (
-            <Tooltip title="Your microphone is on" sx={{ color: theme.palette.secondary.main }}>
-              <IconButton disableFocusRipple disableTouchRipple>
-                <MicIcon onClick={handleStopListening} />
-              </IconButton>
-            </Tooltip>
-          ) : (
-            <Tooltip title="Your microphone is off" sx={{ color: theme.palette.secondary.main }}>
-              <IconButton onClick={handleStartListening} disableFocusRipple disableTouchRipple>
-                <MicOffIcon>Voice Control Off</MicOffIcon>
-              </IconButton>
-            </Tooltip>
-          )}
-
-        </Box>
-      ) : (
-        <Box sx={{ display: 'flex' }}>
-
-          <IconButton disabled>
-            <InfoIcon />
-          </IconButton>
-
-          <IconButton disabled>
+      { browserSupportsSpeechRecognition ? (
+        <Tooltip
+          title={(
+            <div>
+              Your browser supports voice recognition. <br />
+              <br />
+              Troubleshooting: <br />
+              Voice control is not supported across all browsers. <br />
+              The best native experience is on desktop Google Chrome. <br />
+              Ensure that you give microphone permissions to AIRON.
+            </div>
+  )}
+          sx={{ color: theme.palette.secondary.main }}
+        >
+          <IconButton disableFocusRipple disableTouchRipple>
             <RecordVoiceOverIcon />
           </IconButton>
-
-          <IconButton disabled>
-            <SpeakerNotesIcon />
+        </Tooltip>
+      ) : (
+        <Tooltip
+          title={(
+            <div>
+              Your browser does not support voice recognition. <br />
+              <br />
+              Troubleshooting: <br />
+              Voice control is not supported across all browsers. <br />
+              The best native experience is on desktop Google Chrome. <br />
+              Ensure that you give microphone permissions to AIRON.
+            </div>
+)}
+          sx={{ color: theme.palette.secondary.main }}
+        >
+          <IconButton disableFocusRipple disableTouchRipple>
+            <VoiceOverOffIcon />
           </IconButton>
-
-          <IconButton disabled>
-            <MicOffIcon />
-          </IconButton>
-        </Box>
+        </Tooltip>
       )}
+
+      <Tooltip
+        sx={{ color: theme.palette.secondary.main }}
+        title={(
+          <div>
+            Speech Transcript: <br />
+            <br />
+            {transcript}
+          </div>
+)}
+      >
+        <IconButton disableFocusRipple disableTouchRipple>
+          <SpeakerNotesIcon />
+        </IconButton>
+      </Tooltip>
+
+      { listening ? (
+        <Tooltip title="Your microphone is on" sx={{ color: theme.palette.secondary.main }}>
+          <IconButton disableFocusRipple disableTouchRipple>
+            <MicIcon onClick={handleStopListening} />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Tooltip title="Your microphone is off" sx={{ color: theme.palette.secondary.main }}>
+          <IconButton onClick={handleStartListening} disableFocusRipple disableTouchRipple>
+            <MicOffIcon>Voice Control Off</MicOffIcon>
+          </IconButton>
+        </Tooltip>
+      )}
+
     </Box>
 
   );
@@ -211,5 +187,4 @@ Dictaphone.propTypes = {
   decrementTimerCustom: PropTypes.func.isRequired,
   finishSet: PropTypes.func.isRequired,
   pause: PropTypes.bool.isRequired,
-  slideIsInView: PropTypes.bool.isRequired,
 };

--- a/client/src/components/Workout/VoiceRecognition/DictaphoneDisabled.jsx
+++ b/client/src/components/Workout/VoiceRecognition/DictaphoneDisabled.jsx
@@ -1,0 +1,31 @@
+import InfoIcon from '@mui/icons-material/Info';
+import MicOffIcon from '@mui/icons-material/MicOff';
+import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
+import SpeakerNotesIcon from '@mui/icons-material/SpeakerNotes';
+import {
+  Box, IconButton,
+} from '@mui/material';
+import React from 'react';
+
+export default function DictaphoneDisabled() {
+  return (
+    <Box sx={{ display: 'flex' }}>
+
+      <IconButton disabled>
+        <InfoIcon />
+      </IconButton>
+
+      <IconButton disabled>
+        <RecordVoiceOverIcon />
+      </IconButton>
+
+      <IconButton disabled>
+        <SpeakerNotesIcon />
+      </IconButton>
+
+      <IconButton disabled>
+        <MicOffIcon />
+      </IconButton>
+    </Box>
+  );
+}


### PR DESCRIPTION
Significant bug where state handlers update state for each GuidedExercise simultaneously. Happened due to the way I changed conditional rendering of the Dictaphone. 

Before, if the slide was in view, the Dictaphone would disable itself. Now, GuidedExercises will control whether the Dictaphone is disabled or not by rendering a separate disabled component. 

This is due to some weirdness with carousel rendering, where each slide is actually rendered at the same time upon loading the carousel component in. 